### PR TITLE
don't set bridge device ip address

### DIFF
--- a/drivers/bridge/port_mapping.go
+++ b/drivers/bridge/port_mapping.go
@@ -16,6 +16,11 @@ var (
 )
 
 func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, reqDefBindIP net.IP, ulPxyEnabled bool) ([]types.PortBinding, error) {
+	// endpoint address can't be nil when allocate ports.
+	if ep.addr == nil {
+		return nil, fmt.Errorf("allocatePorts addr is null.")
+	}
+
 	if ep.extConnConfig == nil || ep.extConnConfig.PortBindings == nil {
 		return nil, nil
 	}

--- a/drivers/bridge/setup_ipv4.go
+++ b/drivers/bridge/setup_ipv4.go
@@ -34,13 +34,14 @@ func setupBridgeIPv4(config *networkConfiguration, i *bridgeInterface) error {
 
 	addrv4, _ := selectIPv4Address(addrv4List, config.AddressIPv4)
 
-	if !types.CompareIPNet(addrv4.IPNet, config.AddressIPv4) {
+	// Bridge device may be set by user, so just set bridge device ip address when device is created by libnetwork.
+	if config.BridgeIfaceCreator == ifaceCreatedByLibnetwork && !types.CompareIPNet(addrv4.IPNet, config.AddressIPv4) {
 		if addrv4.IPNet != nil {
 			if err := i.nlh.AddrDel(i.Link, &addrv4); err != nil {
 				return fmt.Errorf("failed to remove current ip address from bridge: %v", err)
 			}
 		}
-		logrus.Debugf("Assigning address to bridge interface %s: %s", config.BridgeName, config.AddressIPv4)
+		logrus.Infof("Assigning address to bridge interface %s: %s", config.BridgeName, config.AddressIPv4)
 		if err := i.nlh.AddrAdd(i.Link, &netlink.Addr{IPNet: config.AddressIPv4}); err != nil {
 			return &IPv4AddrAddError{IP: config.AddressIPv4, Err: err}
 		}

--- a/drivers/bridge/setup_verify.go
+++ b/drivers/bridge/setup_verify.go
@@ -21,13 +21,17 @@ func setupVerifyAndReconcile(config *networkConfiguration, i *bridgeInterface) e
 
 	// Verify that the bridge does have an IPv4 address.
 	if addrv4.IPNet == nil {
-		return &ErrNoIPAddr{}
+		// we set bridge ip address by other network tools,
+		// so don't return error when address is nil.
+		return nil
 	}
 
 	// Verify that the bridge IPv4 address matches the requested configuration.
-	if config.AddressIPv4 != nil && !addrv4.IP.Equal(config.AddressIPv4.IP) {
-		return &IPv4AddrNoMatchError{IP: addrv4.IP, CfgIP: config.AddressIPv4.IP}
-	}
+	// we set bridge ip address by other network tools, so don't to check address
+	// matches the requested configuration.
+	//if config.AddressIPv4 != nil && !addrv4.IP.Equal(config.AddressIPv4.IP) {
+	//	return &IPv4AddrNoMatchError{IP: addrv4.IP, CfgIP: config.AddressIPv4.IP}
+	//}
 
 	// Verify that one of the bridge IPv6 addresses matches the requested
 	// configuration.


### PR DESCRIPTION
We don't set bridge device ip address, because we will set it by owner
initialize network tool. Bridge network has two network mode, one is nat
with iptables, the other is subnet with host network. Network mode will be
choosed by owner network tool.

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>