### PR TITLE
restore the endpoint priority

### DIFF
--- a/sandbox_store.go
+++ b/sandbox_store.go
@@ -217,6 +217,7 @@ func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 			endpoints:          []*endpoint{},
 			populatedEndpoints: map[string]struct{}{},
 			dbIndex:            sbs.dbIndex,
+			epPriority:         sbs.EpPriority,
 			isStub:             true,
 			dbExists:           true,
 		}


### PR DESCRIPTION
When the libnetwork initializes, it will restore the sandbox from bolt. And it forgets to initialize the epPriority. This PR will restore the endpoint priority

Signed-off-by: Eric Li <lcy041536@gmail.com>